### PR TITLE
fail if Cython isn't installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,7 @@
 import os
 from setuptools import Extension, setup
 
-try:
-    from Cython.Build import cythonize
-except ImportError:
-    cythonize = None
+from Cython.Build import cythonize
 
 
 def ALL_C(folder, exclude=[]):
@@ -28,7 +25,6 @@ extensions = [
         ],
     )
 ]
-if cythonize:
-    extensions = cythonize(extensions)
+extensions = cythonize(extensions)
 
 setup(ext_modules=extensions)


### PR DESCRIPTION
Fixes #1, which was caused by Cython not being installed, this causes an error message in such a case so the user knows what went wrong.